### PR TITLE
Cache consolidated COSMOS catalog

### DIFF
--- a/manada/Sources/cosmos.py
+++ b/manada/Sources/cosmos.py
@@ -36,9 +36,18 @@ class COSMOSCatalog(GalaxyCatalog):
 	def __init__(self, folder, cosmology_parameters):
 		super().__init__(cosmology_parameters)
 
-		# Store the path as a Path object.
 		self.folder = Path(folder)
 
+		cached_catalog: Path = self.folder / '_cached_catalog.npy'
+		if cached_catalog.exists():
+			# We built the catalog earlier, load it
+			self.catalog = np.load(cached_catalog)[:]
+		else:
+			# Build a consolidated catalog from the various COSMOS files
+			self._load_catalog()
+			np.save(cached_catalog, self.catalog)
+
+	def _load_catalog(self):
 		# Combine all partial catalog files
 		catalogs = [unfits(str(self.folder / fn)) for fn in [
 			'real_galaxy_catalog_23.5.fits',


### PR DESCRIPTION
Initializing the COSMOSCatalog takes a bit of time, because it loops over all images to find their pixel sizes.

This lets COSMOSCatalog save its catalog to a ~30 MB file in the COSMOS directory (with ~6 GB other files). When COSMOSCatalog is loaded a second time on a machine, it just loads that one file directly. 

For me, this speeds up the catalog initialization from ~24 seconds to ~6 milliseconds. (Except for the first time you load it, of course.)