### PR TITLE
Reproducible images using a sequence of seeds

### DIFF
--- a/paltas/Configs/config_handler.py
+++ b/paltas/Configs/config_handler.py
@@ -53,7 +53,7 @@ class ConfigHandler():
 		self.base_seed = getattr(
 			self.config_module,
 			'seed',
-			(np.random.randint(2**32 - 1,)))
+			(np.random.randint(np.iinfo(np.int64).max,)))
 		# Make sure base_seed is a sequence, not a number
 		if isinstance(self.base_seed, (int, float)):
 			self.base_seed = (self.base_seed,)
@@ -651,6 +651,8 @@ class ConfigHandler():
 			calling the function repeatedly will return images of different
 			realizations of that population.
 		"""
+		# Generate a new random seed for each call to draw_image in order
+		# to ensure deterministic behavior
 		seed = self.reseed()
 
 		# Draw a new sample if requested
@@ -678,6 +680,9 @@ class ConfigHandler():
 
 	def reseed(self):
 		"""Generates, sets, and returns a new random seed.
+
+		Returns:
+			(tuple): The tuple used to seed numpy.
 		"""
 		if self.reseed_counter == 0:
 			# Use the base seed; perhaps to reproduce one particular image
@@ -698,5 +703,9 @@ class ConfigHandler():
 # https://numba.pydata.org/numba-doc/0.22.1/reference/numpysupported.html#random
 @numba.njit
 def _set_numba_seed(seed):
-	"""Reseeds numba's random number generator"""
+	"""Reseeds numba's random number generator
+
+	Args:
+		seed (int): The integer random seed to use for seeding numba.
+	"""
 	np.random.seed(seed)

--- a/paltas/Configs/config_handler.py
+++ b/paltas/Configs/config_handler.py
@@ -49,10 +49,11 @@ class ConfigHandler():
 
 		# Get the random seed to use, or draw a random not-too-large one
 		# (so it is easy to copy-paste from metadata into config files)
+		# Max is 2**32 - 1, see _legacy_seeding in numpy/random/_mt19937.pyx
 		self.base_seed = getattr(
 			self.config_module,
 			'seed',
-			(np.random.randint(np.iinfo(np.int64).max,)))
+			(np.random.randint(2**32 - 1,)))
 		# Make sure base_seed is a sequence, not a number
 		if isinstance(self.base_seed, (int, float)):
 			self.base_seed = (self.base_seed,)

--- a/paltas/Configs/config_handler.py
+++ b/paltas/Configs/config_handler.py
@@ -37,8 +37,6 @@ class ConfigHandler():
 		config_path (str): A path to the config file to parse.
 	"""
 
-	reseed_counter = 0
-
 	def __init__(self,config_path,):
 		# Get the dictionary from the provided .py file
 		config_dir, config_file = os.path.split(os.path.abspath(config_path))
@@ -57,6 +55,7 @@ class ConfigHandler():
 		# Make sure base_seed is a sequence, not a number
 		if isinstance(self.base_seed, (int, float)):
 			self.base_seed = (self.base_seed,)
+		self.reseed_counter = 0
 
 		# Set up our sampler and draw a sample for initialization
 		self.sampler = Sampler(self.config_dict)

--- a/paltas/Sources/cosmos.py
+++ b/paltas/Sources/cosmos.py
@@ -87,7 +87,7 @@ class COSMOSCatalog(GalaxyCatalog):
 
 		else:
 			# Make the directory where I'm going to save the npy files
-			self.npy_files_path.mkdir()
+			self.npy_files_path.mkdir(exist_ok=True)
 			# Combine all partial catalog files
 			catalogs = [unfits(str(self.folder / fn)) for fn in [
 				'real_galaxy_catalog_23.5.fits',

--- a/paltas/Sources/sersic.py
+++ b/paltas/Sources/sersic.py
@@ -170,8 +170,8 @@ class DoubleSersicData(SingleSersicSource):
 	"""
 
 	required_parameters = ('magnitude', 'f_bulge', 'output_ab_zeropoint',
-		'n_bulge','n_disk','r_disk_bulge','e1','e2','center_x','center_y',
-		'z_source')
+		'n_bulge','n_disk','r_disk_bulge','e1_bulge','e2_bulge','e1_disk',
+		'e2_disk','center_x','center_y','z_source')
 
 	def get_bulge_disk_mag(self):
 		"""Returns the apparent magnitude for the bulge and the disk
@@ -209,21 +209,22 @@ class DoubleSersicData(SingleSersicSource):
 		"""
 		# Define the fit parameters
 		a = 0.6
-		b = -4.63
+		b = -5.06
 		M_0 = -20.52
-		sigma_1, sigma_2 = 0.48, 0.25
+		sigma_1, sigma_2 = 0.45, 0.27
 
 		# Extract the absolute magnitude
 		M = self.source_parameters['magnitude']
 
 		# Start with the mean relation
 		log_R_half = -0.4*a*M+b
+		ln_R_half = np.log(10**log_R_half)
 
 		# Add scatter
-		log_R_half += np.random.randn() * (
+		ln_R_half += np.random.randn() * (
 			sigma_2 + (sigma_1-sigma_2)/(1+10**(-0.8*(M-M_0))))
 
-		return 10**(log_R_half)
+		return np.exp(ln_R_half)
 
 	def get_bulge_disk_half_light(self,R_total):
 		"""Returns the half-light radius for the disk and the bulge.
@@ -302,17 +303,19 @@ class DoubleSersicData(SingleSersicSource):
 
 		# Make the kwargs for both sersics.
 		kwargs_bulge = {'R_sersic':r_half_bulge,
-			'n_sersic':self.source_parameters['n_bulge']}
+			'n_sersic':self.source_parameters['n_bulge'],
+			'e1':self.source_parameters['e1_bulge'],
+			'e2':self.source_parameters['e2_bulge']}
 		kwargs_disk = {'R_sersic':r_half_disk,
-			'n_sersic':self.source_parameters['n_disk']}
+			'n_sersic':self.source_parameters['n_disk'],
+			'e1':self.source_parameters['e1_disk'],
+			'e2':self.source_parameters['e2_disk']}
 		light_model_kwargs = [kwargs_bulge,kwargs_disk]
 
 		# Add the shared parameters.
 		for kwargs in light_model_kwargs:
 			kwargs['center_x'] = self.source_parameters['center_x']
 			kwargs['center_y'] = self.source_parameters['center_y']
-			kwargs['e1'] = self.source_parameters['e1']
-			kwargs['e2'] = self.source_parameters['e2']
 
 		# Get the amplitude for each component
 		amp_bulge = SingleSersicSource.mag_to_amplitude(mag_bulge,

--- a/test/config_tests.py
+++ b/test/config_tests.py
@@ -580,3 +580,25 @@ class ConfigUtilsTests(unittest.TestCase):
 		image_small,metadata = self.c.draw_image(new_sample=False)
 		self.assertEqual(metadata['main_deflector_parameters_theta_E'],0.1)
 		self.assertLess(np.sum(image_small),np.sum(image))
+
+	def test_draw_image_reproducible(self):
+		# Test we can reproduce generated images by setting appropriate
+		# random seeds
+		c = config_handler.ConfigHandler('test_data/config_dict_drizz.py')
+		img_1, meta_1 = c.draw_image()
+		img_2, meta_2 = c.draw_image()
+		seed_1, seed_2 = meta_1['seed'], meta_2['seed']
+		assert not np.all(img_1 == img_2), "Images should be different"
+
+		# Just set the base_seed attribute manually; simpler than building
+		# a temporary config file
+		c_1 = config_handler.ConfigHandler('test_data/config_dict_drizz.py')
+		c_1.base_seed = seed_1
+		img_1a, _ = c_1.draw_image()
+		np.testing.assert_allclose(img_1, img_1a)
+
+		# Test this works even for an image in the middle of a training set
+		c_2 = config_handler.ConfigHandler('test_data/config_dict_drizz.py')
+		c_2.base_seed = seed_2
+		img_2a, _ = c_2.draw_image()
+		np.testing.assert_allclose(img_2, img_2a)

--- a/test/generate_tests.py
+++ b/test/generate_tests.py
@@ -33,7 +33,7 @@ class GenerateTests(unittest.TestCase):
 		n_generate = 21
 		output_folder = 'test_data/test_dataset'
 		sys.argv = ['test','test_data/config_dict.py',output_folder,'--n',
-			str(n_generate),'--tf_record','--save_png_too']
+			str(n_generate),'--save_png_too']
 		generate.main()
 
 		image_file_list = glob.glob(os.path.join(output_folder,'image_*.npy'))
@@ -75,7 +75,6 @@ class GenerateTests(unittest.TestCase):
 		# Remove the metadata file
 		os.remove(os.path.join(output_folder,'metadata.csv'))
 		os.remove(os.path.join(output_folder,'config_dict.py'))
-		os.remove(os.path.join(output_folder,'data.tfrecord'))
 
 		# Remove the images
 		for i in range(n_generate):

--- a/test/generate_tests.py
+++ b/test/generate_tests.py
@@ -4,6 +4,12 @@ import unittest
 import sys, glob, copy, os
 from paltas import generate
 
+try:
+	import tensorflow as tf
+	tensorflow_installed = True
+except ImportError:
+	tensorflow_installed = False
+
 # Define the cosmos path
 cosmos_folder = 'test_data/cosmos/'
 
@@ -96,6 +102,8 @@ class GenerateTests(unittest.TestCase):
 		output_folder = 'test_data/test_dataset'
 		sys.argv = ['test','test_data/config_dict_drizz.py',output_folder,
 			'--n','10']
+		if tensorflow_installed:
+			sys.argv.append('--tf_record')
 		generate.main()
 
 		image_file_list = glob.glob(os.path.join(output_folder,'image_*.npy'))
@@ -136,6 +144,8 @@ class GenerateTests(unittest.TestCase):
 		# Remove the metadata file
 		os.remove(os.path.join(output_folder,'metadata.csv'))
 		os.remove(os.path.join(output_folder,'config_dict_drizz.py'))
+		if tensorflow_installed:
+			os.remove(os.path.join(output_folder,'data.tfrecord'))
 
 		sys.argv = old_sys
 

--- a/test/source_tests.py
+++ b/test/source_tests.py
@@ -184,8 +184,8 @@ class DoubleSersicDataTests(SourceBaseTests):
 		super().setUp()
 		self.source_parameters = {'magnitude':-17, 'f_bulge':0.5,
 		'output_ab_zeropoint':25,'n_bulge':1,'n_disk':4,
-		'r_disk_bulge':2,'e1':0.0,'e2':0.0,'center_x':0.0,'center_y':0.0,
-		'z_source':0.5}
+		'r_disk_bulge':2,'e1_bulge':0.0,'e2_bulge':0.0,'e1_disk':0.1,
+		'e2_disk':0.1,'center_x':0.0,'center_y':0.0,'z_source':0.5}
 		self.c = DoubleSersicData(cosmology_parameters='planck18',
 			source_parameters=self.source_parameters)
 		np.random.seed(4)
@@ -225,8 +225,8 @@ class DoubleSersicDataTests(SourceBaseTests):
 		half_lights = []
 		for _ in range(int(1e4)):
 			half_lights.append(self.c.get_total_half_light())
-		self.assertAlmostEqual(np.mean(np.log10(half_lights)),-0.55,places=1)
-		self.assertAlmostEqual(np.std(np.log10(half_lights)),0.48,places=1)
+		self.assertAlmostEqual(np.mean(np.log10(half_lights)),-0.98,places=1)
+		self.assertAlmostEqual(np.std(np.log(half_lights)),0.45,places=1)
 
 		# Shift to a higher magnitude and make sure the standard deviation and
 		# mean shifts.
@@ -234,8 +234,8 @@ class DoubleSersicDataTests(SourceBaseTests):
 		half_lights = []
 		for _ in range(int(1e4)):
 			half_lights.append(self.c.get_total_half_light())
-		self.assertAlmostEqual(np.mean(np.log10(half_lights)),0.89,places=1)
-		self.assertAlmostEqual(np.std(np.log10(half_lights)),0.25,places=1)
+		self.assertAlmostEqual(np.mean(np.log10(half_lights)),0.46,places=1)
+		self.assertAlmostEqual(np.std(np.log(half_lights)),0.27,places=1)
 
 	def test_get_bulge_disk_half_light(self):
 		# Test that the model produced by the function respects the total
@@ -288,6 +288,13 @@ class DoubleSersicDataTests(SourceBaseTests):
 		lens_model = LensModel(['SPEP'])
 		light_model = LightModel(light_models)
 
+		# Check that the ellipticites have been set correctly
+		self.assertEqual(light_kwargs_list[0]['e1'],0.0)
+		self.assertEqual(light_kwargs_list[0]['e2'],0.0)
+		self.assertEqual(light_kwargs_list[1]['e1'],0.1)
+		self.assertEqual(light_kwargs_list[1]['e2'],0.1)
+
+		# Make sure the sources play well with lenstronomy
 		n_pixels = 200
 		pixel_width = 0.08
 		image_model = ImageModel(


### PR DESCRIPTION
This PR makes it possible to reproduce datasets, and individual images from training datasets (without generating all previous images). This should be useful e.g. to generate converge maps, or the list of subhalo masses and positions, for specific images in datasets we are interested in.

Paltas already  allows you to set the numpy random seed via the config. However, it also draws some random numbers from numba, which uses a separate random number generator. Thus, setting the seed in paltas' config does not yet result in predictable images. This also means some of the unit tests are not fully deterministic.

After this PR: 
  * We re-seed the numpy random number generator before generating each image, and seed the separate numba random generator right after that.
  * The first generated image uses a base seed. The second uses a tuple (base_seed, 1) as a seed (or base_seed + (1,) if base_seed is already a tuple), then (base_seed, 2), etc. Numpy uses [SeedSequence](https://numpy.org/doc/stable/reference/random/bit_generators/generated/numpy.random.SeedSequence.html#numpy.random.SeedSequence) internally to turn these low-quality (not very random) seeds into high-quality seeds, see e.g. [here](https://numpy.org/doc/stable/reference/random/bit_generators/mt19937.html#mersenne-twister-mt19937).
  * If the user doesn't specify a base seed to use in the config, `ConfigHandler` will set the random number generator seed to a random int64. (We could use a larger seed, but this way seeds are still easy to copy-paste from metadata.)

We're not exactly following best practice with random number generators: current wisdom avoids `np.seed` and instead makes separate random generator instances and passes them around the code. That would be a much bigger change affecting the entire code though.

Two minor changes smuggled in:
  * When creating the folder with npy images files, allow the folder to already exist. The mkdir can be triggered if the folder already exists, when the catalog's main npy is missing (for some reason).
  * Do not create a tfrecord during the generate tests, so we can run all the non-analysis tests in environments without tensorflow. The tfrecord was not actually tested anyway (other than implicity requiring it exists by the os.remove cleanup statement). If you'd rather the file is made during testing we could e.g. check if tf imports, and only ask for the tfrecord in the tests if it does.