### PR TITLE
Common base class for extensibility and reduced boilerplate

### DIFF
--- a/paltas/MainDeflector/main_deflector_base.py
+++ b/paltas/MainDeflector/main_deflector_base.py
@@ -6,11 +6,12 @@ This module contains the base class that all the main deflector classes will
 build from. Because the steps for rendering a main deflector can vary between
 different models, the required functions are very sparse.
 """
+import paltas
 from ..Utils.cosmology_utils import get_cosmology
 import copy
 
 
-class MainDeflectorBase():
+class MainDeflectorBase(paltas.BaseComponent):
 	"""Base class for rendering the main halo.
 
 	Args:
@@ -84,3 +85,6 @@ class MainDeflectorBase():
 			redshift for each component.
 		"""
 		raise NotImplementedError
+
+	def draw(self, result, **kwargs):
+		result.add_lenses(*self.draw_main_deflector())

--- a/paltas/MainDeflector/main_deflector_base.py
+++ b/paltas/MainDeflector/main_deflector_base.py
@@ -7,8 +7,6 @@ build from. Because the steps for rendering a main deflector can vary between
 different models, the required functions are very sparse.
 """
 import paltas
-from ..Utils.cosmology_utils import get_cosmology
-import copy
 
 
 class MainDeflectorBase(paltas.BaseComponent):
@@ -23,56 +21,7 @@ class MainDeflectorBase(paltas.BaseComponent):
 			dict with H0 and Om0 ( other parameters will be set to defaults).
 	"""
 
-	required_parameters = tuple()
-
-	def __init__(self,main_deflector_parameters,cosmology_parameters):
-
-		# Save the parameters as a copy to avoid any misunderstanding on the
-		# user end.
-		self.main_deflector_parameters = copy.deepcopy(
-			main_deflector_parameters)
-
-		# Turn our cosmology parameters into a colossus cosmology instance
-		self.cosmo = get_cosmology(cosmology_parameters)
-
-		# Check that all the needed parameters are present
-		self.check_parameterization(self.__class__.required_parameters)
-
-	def check_parameterization(self,required_params):
-		""" Check that all the required parameters are present in the
-		los_parameters.
-
-		Args:
-			required_params ([str,...]): A list of strings containing the
-				required parameters.
-		"""
-		if not all(elem in self.main_deflector_parameters.keys() for
-			elem in required_params):
-			raise ValueError('Not all of the required parameters for the ' +
-				'parameterization are present.')
-
-	def update_parameters(self,main_deflector_parameters=None,
-		cosmology_parameters=None):
-		"""Updated the class parameters
-
-		Args:
-			los_parameters (dict): A dictionary containing the type of
-				los distribution and the value for each of its parameters.
-			main_deflector_parameters (dict): A dictionary containing the type
-				of main deflector and the value for each of its parameters.
-			source_parameters (dict): A dictionary containing the type of the
-				source and the value for each of its parameters.
-			cosmology_parameters (str,dict, or colossus.cosmology.Cosmology):
-				Either a name of colossus cosmology, a dict with 'cosmology name':
-				name of colossus cosmology, an instance of colussus cosmology, or
-				a dict with H0 and Om0 ( other parameters will be set to
-				defaults).
-		"""
-		if main_deflector_parameters is not None:
-			self.main_deflector_parameters = copy.copy(
-				main_deflector_parameters)
-		if cosmology_parameters is not None:
-			self.cosmo = get_cosmology(cosmology_parameters)
+	init_kwargs = ('main_deflector_parameters', 'cosmology_parameters')
 
 	def draw_main_deflector(self):
 		"""Draws the lenstronomy profile names and kwargs for the components

--- a/paltas/PointSource/point_source_base.py
+++ b/paltas/PointSource/point_source_base.py
@@ -8,8 +8,10 @@ models, the required functions are very sparse.
 """
 import copy
 
+import paltas
 
-class PointSourceBase:
+
+class PointSourceBase(paltas.BaseComponent):
 	"""
 	Base class for producing lenstronomy PointSource arguments
 
@@ -60,3 +62,6 @@ class PointSourceBase:
 			a list containing the model kwargs dictionaries.
 		"""
 		raise NotImplementedError
+
+	def draw(self, result, **kwargs):
+		result.add_point_sources(*self.draw_point_source())

--- a/paltas/PointSource/point_source_base.py
+++ b/paltas/PointSource/point_source_base.py
@@ -6,8 +6,6 @@ This module contains the base class that all the point source classes will
 build from. Because the steps for rendering a source can vary between different
 models, the required functions are very sparse.
 """
-import copy
-
 import paltas
 
 
@@ -23,36 +21,7 @@ class PointSourceBase(paltas.BaseComponent):
 		Has no required parameters by default.
 	"""
 
-	required_parameters = tuple()
-
-	def __init__(self, point_source_parameters):
-		self.point_source_parameters = copy.deepcopy(point_source_parameters)
-
-		# Check that all the required parameters are present
-		self.check_parameterization(self.__class__.required_parameters)
-
-	def check_parameterization(self, required_params):
-		""" Check that all the required parameters are present in the
-		point_source_parameters.
-
-		Args:
-			required_params ([str,...]): A list of strings containing the
-				required parameters.
-		"""
-		if not all(elem in self.point_source_parameters.keys() for
-			elem in required_params):
-			raise ValueError('Not all of the required parameters for the ' +
-				'parameterization are present.')
-
-	def update_parameters(self, point_source_parameters=None):
-		"""Update the class parameters
-
-		Args:
-			point_source_parameters (dict): A dictionary containing all the 
-				parameters needed to draw point sources.
-		"""
-		if point_source_parameters is not None:
-			self.point_source_parameters.update(point_source_parameters)
+	init_kwargs = ('point_source_parameters',)
 
 	def draw_point_source(self):
 		"""Return lenstronomy PointSource names and kwargs

--- a/paltas/Sources/galaxy_catalog.py
+++ b/paltas/Sources/galaxy_catalog.py
@@ -273,3 +273,19 @@ class GalaxyCatalog(SourceBase):
 		return (
 			self.cosmo.angularDiameterDistance(z_old)
 			/ self.cosmo.angularDiameterDistance(z_new))
+
+	def draw(self, result, *, sample, lens_light, **kwargs):
+		# For catalog objects we also want to save the catalog index
+		# and the (possibly randomized) additional rotation angle. We will
+		# therefore push these back into the sample object.
+		catalog_i, phi = self.fill_catalog_i_phi_defaults()
+		if lens_light:
+			result.add_lens_light(
+				*self.draw_source(catalog_i=catalog_i, phi=phi))
+			sample['lens_light_parameters']['catalog_i'] = catalog_i
+			sample['lens_light_parameters']['phi'] = phi
+		else:
+			result.add_sources(
+				*self.draw_source(catalog_i=catalog_i, phi=phi))
+			sample['source_parameters']['catalog_i'] = catalog_i
+			sample['source_parameters']['phi'] = phi

--- a/paltas/Sources/source_base.py
+++ b/paltas/Sources/source_base.py
@@ -9,8 +9,10 @@ models, the required functions are very sparse.
 import copy
 from ..Utils.cosmology_utils import get_cosmology
 
+import paltas
 
-class SourceBase():
+
+class SourceBase(paltas.BaseComponent):
 	"""
 	Base class for producing lenstronomy LightModel arguments
 
@@ -71,3 +73,9 @@ class SourceBase():
 			be None.
 		"""
 		raise NotImplementedError
+
+	def draw(self, result, lens_light=False, **kwargs):
+		if lens_light:
+			result.add_lens_light(*self.draw_source())
+		else:
+			result.add_sources(*self.draw_source())

--- a/paltas/Sources/source_base.py
+++ b/paltas/Sources/source_base.py
@@ -24,44 +24,9 @@ class SourceBase(paltas.BaseComponent):
 		source_parameters (dict): dictionary with source-specific parameters
 	"""
 
-	required_parameters = tuple()
-
-	def __init__(self, cosmology_parameters, source_parameters):
-		self.cosmo = get_cosmology(cosmology_parameters)
-		self.source_parameters = copy.deepcopy(source_parameters)
-
-		# Check that all the required parameters are present
-		self.check_parameterization(self.__class__.required_parameters)
-
-	def check_parameterization(self, required_params):
-		""" Check that all the required parameters are present in the
-		source_parameters.
-
-		Args:
-			required_params ([str,...]): A list of strings containing the
-				required parameters.
-		"""
-		if not all(elem in self.source_parameters.keys() for
-			elem in required_params):
-			raise ValueError('Not all of the required parameters for the ' +
-				'parameterization are present.')
-
-	def update_parameters(self, cosmology_parameters=None,source_parameters=None):
-		"""Updated the class parameters
-
-		Args:
-			cosmology_parameters (str,dict, or colossus.cosmology.Cosmology):
-				Either a name of colossus cosmology, a dict with 'cosmology name':
-				name of colossus cosmology, an instance of colussus cosmology, or
-				a dict with H0 and Om0 ( other parameters will be set to
-				defaults).
-			source_parameters (dict): A dictionary containing all the parameters
-				needed to draw sources.
-		"""
-		if source_parameters is not None:
-			self.source_parameters.update(source_parameters)
-		if cosmology_parameters is not None:
-			self.cosmo = get_cosmology(cosmology_parameters)
+	# Historical oversight: cosmology parameters as first arg...
+	init_kwargs = ('cosmology_parameters', 'source_parameters')
+	main_param_dict_name = 'source_parameters'
 
 	def draw_source(self):
 		"""Return lenstronomy LightModel names and kwargs

--- a/paltas/Substructure/los_base.py
+++ b/paltas/Substructure/los_base.py
@@ -9,8 +9,10 @@ models, the required functions are very sparse.
 from ..Utils.cosmology_utils import get_cosmology
 import copy
 
+import paltas
 
-class LOSBase():
+
+class LOSBase(paltas.BaseComponent):
 	"""Base class for rendering the los of a main halo.
 
 	Args:
@@ -107,8 +109,15 @@ class LOSBase():
 				interpolation maps.
 
 		Returns:
-			(tuple): A tuple of two lists: the first is the interpolation
+			(tuple): A tuple of three lists: the first is the interpolation
 			profile type for each redshift slice and the second is the
-			lenstronomy kwargs for that profile.
+			lenstronomy kwargs for each profile, and the third is a list of 
+			redshift values for each profile.
 		"""
 		raise NotImplementedError
+
+
+	def draw(self, result, *, kwargs_numerics, numpix, **kwargs):
+		result.add_lenses(*self.draw_los())
+		result.add_lenses(*self.calculate_average_alpha(
+			numpix * kwargs_numerics['supersampling_factor']))

--- a/paltas/Substructure/los_base.py
+++ b/paltas/Substructure/los_base.py
@@ -6,9 +6,6 @@ This module contains the base class that all the los classes will build
 from. Because the steps for rendering halos can vary between different
 models, the required functions are very sparse.
 """
-from ..Utils.cosmology_utils import get_cosmology
-import copy
-
 import paltas
 
 
@@ -28,64 +25,9 @@ class LOSBase(paltas.BaseComponent):
 			dict with H0 and Om0 ( other parameters will be set to defaults).
 	"""
 
-	required_parameters = tuple()
-
-	def __init__(self,los_parameters,main_deflector_parameters,
-		source_parameters,cosmology_parameters):
-
-		# Save the parameters as a copy to avoid any misunderstanding on the
-		# user end.
-		self.los_parameters = copy.deepcopy(los_parameters)
-		self.main_deflector_parameters = copy.deepcopy(
-			main_deflector_parameters)
-		self.source_parameters = copy.deepcopy(source_parameters)
-
-		# Turn our cosmology parameters into a colossus cosmology instance
-		self.cosmo = get_cosmology(cosmology_parameters)
-
-		# Check that all the needed parameters are present
-		self.check_parameterization(self.__class__.required_parameters)
-
-	def check_parameterization(self,required_params):
-		""" Check that all the required parameters are present in the
-		los_parameters.
-
-		Args:
-			required_params ([str,...]): A list of strings containing the
-				required parameters.
-		"""
-		if not all(elem in self.los_parameters.keys() for
-			elem in required_params):
-			raise ValueError('Not all of the required parameters for the ' +
-				'parameterization are present.')
-
-	def update_parameters(self,los_parameters=None,
-		main_deflector_parameters=None,source_parameters=None,
-		cosmology_parameters=None):
-		"""Updated the class parameters
-
-		Args:
-			los_parameters (dict): A dictionary containing the type of
-				los distribution and the value for each of its parameters.
-			main_deflector_parameters (dict): A dictionary containing the type
-				of main deflector and the value for each of its parameters.
-			source_parameters (dict): A dictionary containing the type of the
-				source and the value for each of its parameters.
-			cosmology_parameters (str,dict, or colossus.cosmology.Cosmology):
-				Either a name of colossus cosmology, a dict with 'cosmology name':
-				name of colossus cosmology, an instance of colussus cosmology, or
-				a dict with H0 and Om0 ( other parameters will be set to
-				defaults).
-		"""
-		if los_parameters is not None:
-			self.los_parameters = copy.copy(los_parameters)
-		if main_deflector_parameters is not None:
-			self.main_deflector_parameters = copy.copy(
-				main_deflector_parameters)
-		if source_parameters is not None:
-			self.source_parameters = copy.copy(source_parameters)
-		if cosmology_parameters is not None:
-			self.cosmo = get_cosmology(cosmology_parameters)
+	init_kwargs = (
+		'los_parameters', 'main_deflector_parameters',
+		'source_parameters', 'cosmology_parameters')
 
 	def draw_los(self):
 		"""Draws masses, concentrations,and positions for the los substructure
@@ -115,7 +57,6 @@ class LOSBase(paltas.BaseComponent):
 			redshift values for each profile.
 		"""
 		raise NotImplementedError
-
 
 	def draw(self, result, *, kwargs_numerics, numpix, **kwargs):
 		result.add_lenses(*self.draw_los())

--- a/paltas/Substructure/los_dg19.py
+++ b/paltas/Substructure/los_dg19.py
@@ -479,9 +479,10 @@ class LOSDG19(LOSBase):
 				interpolation maps.
 
 		Returns:
-			(tuple): A tuple of two lists: the first is the interpolation
+			(tuple): A tuple of three lists: the first is the interpolation
 			profile type for each redshift slice and the second is the
-			lenstronomy kwargs for that profile.
+			lenstronomy kwargs for each profile, and the third is a list of 
+			redshift values for each profile.
 
 		Notes:
 			The average los deflection angles of the lenstronomy objects will

--- a/paltas/Substructure/subhalos_base.py
+++ b/paltas/Substructure/subhalos_base.py
@@ -6,9 +6,6 @@ This module contains the base class that all the subhalo classes will build
 from. Because the steps for rendering subhalos can vary between different
 models, the required functions are very sparse.
 """
-from ..Utils.cosmology_utils import get_cosmology
-import copy
-
 import paltas
 
 
@@ -28,66 +25,9 @@ class SubhalosBase(paltas.BaseComponent):
 			dict with H0 and Om0 ( other parameters will be set to defaults).
 	"""
 
-	required_parameters = tuple()
-
-	def __init__(self,subhalo_parameters,main_deflector_parameters,
-		source_parameters,cosmology_parameters):
-
-		# Save the parameters as a copy to avoid user confusion
-		self.subhalo_parameters = copy.deepcopy(subhalo_parameters)
-		self.main_deflector_parameters = copy.deepcopy(
-			main_deflector_parameters)
-		self.source_parameters = copy.deepcopy(source_parameters)
-
-		# Turn our cosmology parameters into a colossus cosmology instance
-		self.cosmo = get_cosmology(cosmology_parameters)
-
-		# Check that all the needed parameters are present
-		self.check_parameterization(self.__class__.required_parameters)
-
-	def check_parameterization(self,required_params):
-		""" Check that all the required parameters are present in the
-		subhalo_parameters.
-
-		Args:
-			required_params ([str,...]): A list of strings containing the
-				required parameters.
-		"""
-		if not all(elem in self.subhalo_parameters.keys() for
-			elem in required_params):
-			raise ValueError('Not all of the required parameters for the ' +
-				'parameterization are present.')
-
-	def update_parameters(self,subhalo_parameters=None,
-		main_deflector_parameters=None,source_parameters=None,
-		cosmology_parameters=None):
-		"""Updated the class parameters
-
-		Args:
-			subhalo_parameters (dict): A dictionary containing the type of
-				los distribution and the value for each of its parameters.
-			main_deflector_parameters (dict): A dictionary containing the type
-				of main deflector and the value for each of its parameters.
-			source_parameters (dict): A dictionary containing the type of the
-				source and the value for each of its parameters.
-			cosmology_parameters (str,dict, or colossus.cosmology.Cosmology):
-				Either a name of colossus cosmology, a dict with 'cosmology name':
-				name of colossus cosmology, an instance of colussus cosmology, or
-				a dict with H0 and Om0 ( other parameters will be set to
-				defaults).
-
-		Notes:
-			Use this function to update parameter values instead of
-			starting a new class.
-		"""
-		if subhalo_parameters is not None:
-			self.subhalo_parameters.update(subhalo_parameters)
-		if main_deflector_parameters is not None:
-			self.main_deflector_parameters.update(main_deflector_parameters)
-		if source_parameters is not None:
-			self.source_parameters.update(source_parameters)
-		if cosmology_parameters is not None:
-			self.cosmo = get_cosmology(cosmology_parameters)
+	init_kwargs = (
+		'subhalo_parameters', 'main_deflector_parameters', 
+		'source_parameters', 'cosmology_parameters')
 
 	def draw_subhalos(self):
 		"""Draws masses, concentrations,and positions for the subhalos of a

--- a/paltas/Substructure/subhalos_base.py
+++ b/paltas/Substructure/subhalos_base.py
@@ -9,8 +9,10 @@ models, the required functions are very sparse.
 from ..Utils.cosmology_utils import get_cosmology
 import copy
 
+import paltas
 
-class SubhalosBase():
+
+class SubhalosBase(paltas.BaseComponent):
 	""" Base class for rendering the subhalos of a main halo.
 
 	Args:
@@ -97,3 +99,6 @@ class SubhalosBase():
 			that subhalo, and the third is the redshift for each subhalo.
 		"""
 		raise NotImplementedError
+
+	def draw(self, result, **kwargs):
+		result.add_lenses(*self.draw_subhalos())

--- a/paltas/__init__.py
+++ b/paltas/__init__.py
@@ -4,6 +4,7 @@ __version__ = '0.1.1'
 
 # Analysis is not imported by default because it required tensorflow.
 
+from .core import *
 from . import Configs
 from . import Sampling
 from . import Sources

--- a/paltas/core.py
+++ b/paltas/core.py
@@ -1,0 +1,22 @@
+import inspect
+
+__all__ = ['BaseComponent']
+
+
+class BaseComponent:
+	"""Base class for all paltas models (e.g. SourceBase) """
+
+	@classmethod
+	def init_from_sample(cls, sample):
+		return cls(**cls._sample_to_kwargs(sample))
+
+	def update_from_sample(self, sample):
+		self.update_parameters(**self._sample_to_kwargs(sample))
+
+	@classmethod
+	def _sample_to_kwargs(cls, sample):
+		if not hasattr(cls, '__init_kwargs'):
+			# Find out which arguments __init__ takes
+			sig = inspect.signature(cls.__init__)
+			cls.__init_kwargs = [p for p in sig.parameters.keys() if p != 'self']
+		return {p: sample[p] for p in cls.__init_kwargs}

--- a/paltas/core.py
+++ b/paltas/core.py
@@ -1,10 +1,60 @@
-import inspect
-
-__all__ = ['BaseComponent']
-
 
 class BaseComponent:
 	"""Base class for all paltas models (e.g. SourceBase) """
+
+	init_kwargs = tuple()
+	required_parameters = tuple()
+
+	@property
+	def main_param_dict_name(self):
+		return self.init_kwargs[0]
+
+	def __init__(self, *args, **kwargs):
+		# Fold in any positional arguments
+		kwargs.update(dict(zip(self.init_kwargs, args)))
+
+		for dict_name in self.init_kwargs:
+			setattr(self, dict_name, dict())
+		self.update_parameters(**kwargs, _first_time=True)
+
+		# Check that all the required parameters are present
+		self.check_parameterization(self.required_parameters)
+
+	def update_parameters(self, *args, _first_time=False, **kwargs):
+		"""Updated the parameters
+
+		Args:
+			Dictionary for each argument named in _init_kwargs
+
+		Notes:
+			Use this function to update parameter values instead of
+			starting a new class.
+		"""
+		# Fold in any positional arguments
+		kwargs.update(dict(zip(self.init_kwargs, args)))
+
+		import paltas
+		for dict_name in self.init_kwargs:
+			if kwargs.get(dict_name) is None:
+				if _first_time:
+					raise ValueError(f"Must provide {dict_name} to init {self}")
+				continue
+			if dict_name == 'cosmology_parameters':
+				self.cosmo = paltas.Utils.cosmology_utils.get_cosmology(
+					kwargs['cosmology_parameters'])
+			else:
+				getattr(self, dict_name).update(kwargs[dict_name])
+
+	def check_parameterization(self,required_params):
+		""" Check that all the required parameters are present
+		"""
+		present_params = set(getattr(self, self.main_param_dict_name).keys())
+		required_params = set(required_params)
+		missing_params = required_params - present_params
+		if missing_params:
+			raise ValueError(
+				f"Missing parameters {missing_params}"
+			 	f" in {self.main_param_dict_name}.")
 
 	@classmethod
 	def init_from_sample(cls, sample):
@@ -15,8 +65,4 @@ class BaseComponent:
 
 	@classmethod
 	def _sample_to_kwargs(cls, sample):
-		if not hasattr(cls, '__init_kwargs'):
-			# Find out which arguments __init__ takes
-			sig = inspect.signature(cls.__init__)
-			cls.__init_kwargs = [p for p in sig.parameters.keys() if p != 'self']
-		return {p: sample[p] for p in cls.__init_kwargs}
+		return {p: sample[p] for p in cls.init_kwargs}

--- a/test/config_tests.py
+++ b/test/config_tests.py
@@ -286,7 +286,7 @@ class ConfigUtilsTests(unittest.TestCase):
 
 		# Now we'll turn off our main deflector but create a fake LOS
 		# and subhalo class that gives the same profile.
-		class FakeLOSClass():
+		class FakeLOSClass(paltas.Substructure.los_base.LOSBase):
 
 			def update_parameters(self,*args,**kwargs):
 				return
@@ -302,14 +302,14 @@ class ConfigUtilsTests(unittest.TestCase):
 			def calculate_average_alpha(self,*args,**kwargs):
 				return ([],[],[])
 
-		self.c.los_class = FakeLOSClass()
+		self.c.los_class = FakeLOSClass.init_from_sample(self.c.sample)
 		self.c.main_deflector_class = None
 		self.c.sample['los_parameters'] = {}
 		los_image, metadata = self.c._draw_image_standard(self.c.add_noise)
 		np.testing.assert_almost_equal(image,los_image)
 
 		# Repeat the same excercise but for the subhalos
-		class FakeSuhaloClass():
+		class FakeSuhaloClass(paltas.Substructure.subhalos_base.SubhalosBase):
 
 			def update_parameters(self,*args,**kwargs):
 				return
@@ -322,14 +322,14 @@ class ConfigUtilsTests(unittest.TestCase):
 				z_list = [0.5]*2
 				return model_list,kwargs_list,z_list
 
-		self.c.subhalo_class = FakeSuhaloClass()
+		self.c.subhalo_class = FakeSuhaloClass.init_from_sample(self.c.sample)
 		self.c.los_class = None
 		self.c.sample['subhalo_parameters'] = {}
 		sub_image, metadata = self.c._draw_image_standard(self.c.add_noise)
 		np.testing.assert_almost_equal(image,sub_image)
 
 		# Generate image with deflector & lens light
-		self.c.sample['lens_light_parameters'] = {'z_source':0.5,'magnitude':20,
+		self.c.sample['lens_light_parameters'] = {'z_source':0.5,'magnitude':19,
 			'output_ab_zeropoint':25.95,'R_sersic':1.,'n_sersic':1.2,'e1':0.,
 			'e2':0.,'center_x':0.0,'center_y':0.0}
 		self.c.lens_light_class = SingleSersicSource(


### PR DESCRIPTION
This introduces two changes:
  * Make the paltas model classes (`SourceBase`, `LOSBase`, etc.) subclasses of a new `BaseComponent` class. This base class takes care of the common init, update, and parameter checking that was previously duplicated across components.
  * Refactor `ConfigModel.get_lenstronomy_models_kwargs` to remove the mostly-duplicated code for initializing and drawing from the different models. In particular, paltas classes now have a `draw` method that calls methods like `add_lenses` or `add_sources` from a common `LenstronomyInputs` object that is passed around. Besides cleaning things up, this will allow us to add features like painting galaxies onto subhalos.
 
I put the new base class in a top-level `core.py`. If you like that, maybe we can move the `ConfigHandler` stuff there too. We could also squirrel away the base class in an obscure utils file.

The tests will fail until https://github.com/swagnercarena/paltas/pull/38 (or at least https://github.com/swagnercarena/paltas/commit/94bfd3d83c8d3bf650dc53ffbcf093224edbcdd2) is merged and we rebase.