### PR TITLE
Images double in size following mag_cut failure

### DIFF
--- a/paltas/Configs/config_handler.py
+++ b/paltas/Configs/config_handler.py
@@ -577,8 +577,16 @@ class ConfigHandler():
 
 		# Use the normal generation class to make our highres image without
 		# noise.
-		image_ss, metadata = self._draw_image_standard(add_noise=False,
-			apply_psf=False)
+		try:
+			image_ss, metadata = self._draw_image_standard(add_noise=False,
+				apply_psf=False)
+		except MagnificationError:
+			# Reset the class properties that were modified, then reraise
+			self.sample = sample_copy
+			self.kwargs_numerics = kwargs_numerics_copy
+			self.numpix = numpix_copy
+			raise
+					
 		self.sample['detector_parameters']['pixel_scale'] = detector_pixel_scale
 		self.numpix = numpix_copy
 


### PR DESCRIPTION
This fixes a bug introduced in #36: when generating images with drizzle and a magnification cut, the size of all future generated images doubles (along both axes) whenever one image fails the magnification cut.

This is because `draw_drizzle` monkeys around with `ConfigHandler`'s stateful attributes, but it is terminated by a [custom exception](https://github.com/swagnercarena/paltas/pull/36#discussion_r918257612) before it cleans up the evidence of its dastardly work.

This PR fixes the bug by catching the exception in _draw_image_drizzle, cleaning up the affected properties, then reraising it.

In the future, we might want to
  * Add a unit test to reproduce this, to avoid regressions
  * Consider cleaner solution, e.g. refactoring _draw_image_drizzle to use a try-finally block, or passing numpix etc. via function arguments rather the ConfigHandler state.
