### PR TITLE
Remove lru_cache on LOS methods

### DIFF
--- a/paltas/Substructure/los_dg19.py
+++ b/paltas/Substructure/los_dg19.py
@@ -11,7 +11,6 @@ import numba
 import numpy as np
 from colossus.lss import peaks, bias
 from ..Utils import power_law, cosmology_utils
-import functools
 from . import nfw_functions
 import lenstronomy.Util.util as util
 from lenstronomy.LensModel.Profiles.nfw import NFW
@@ -121,7 +120,6 @@ class LOSDG19(LOSBase):
 
 		return -1/3*nfn_eval*rho_m/m**2*d_ln_sigma_d_ln_r
 
-	@functools.lru_cache(maxsize=None)
 	def power_law_dn_dm(self,z,m_min,m_max,n_dm=100):
 		"""Returns the best fit power law parameters for the physical number
 		density at a given redshift and mass range.
@@ -192,7 +190,6 @@ class LOSDG19(LOSBase):
 			model='tinker10')
 		return 1+np.mean(xi_halo)
 
-	@functools.lru_cache(maxsize=1024)
 	def cone_angle_to_radius(self,z,z_lens,z_source,cone_angle,
 		angle_buffer=0.8):
 		"""Returns the radius in kpc at the given redshift for the given cone
@@ -228,7 +225,6 @@ class LOSDG19(LOSBase):
 			r_los *= 1 - scal_factor
 		return r_los
 
-	@functools.lru_cache(maxsize=1024)
 	def volume_element(self,z,z_lens,z_source,dz,cone_angle,angle_buffer=0.8):
 		"""Returns the physical volume element at the given redshift
 


### PR DESCRIPTION
This removes the `lru_cache` decorators on some line-of-sight methods. I'm trying to fix some out of memory errors while generating a training set on Sherlock, and while I think #41 is the main problem, these could also contribute.

First, these caches don't actually provide a measurable speedup, at least not when generating a small dataset on my laptop.

Second, `lru_cache` decorators are tricky when used on methods , see e.g. [here](https://rednafi.github.io/reflections/dont-wrap-instance-methods-with-functoolslru_cache-decorator-in-python.html) or [here](https://stackoverflow.com/questions/33672412).
  * The `self` argument is included in the caching calculation, but does not change its hash when its attributes are updated. For example, if we were to marginalize over the cosmology, the answers of some of these functions should change as the self.cosmo attribute changes -- but they won't because they are cached.
  * The cache is kept globally with the class, not with a class instance. That's probably OK here since each ConfigHandler only has one LOS instance, but it is going to cause headache if we're ever going to parallelize with multiple ConfigHandlers.

Finally, the `power_law_dn_dm` cache decorator has an an unbound size. When redshifts are varying, this should cause a (probably small) memory leak. (Besides making the cache of any function that takes a redshift argument useless -- at least as regards to reuse of redshift-dependent computations between images)