### PR TITLE
Fixing deprecation issues causing test errors

### DIFF
--- a/paltas/Analysis/dataset_generation.py
+++ b/paltas/Analysis/dataset_generation.py
@@ -70,7 +70,7 @@ def normalize_outputs(metadata,learning_params,input_norm_path,
 			log_data = metadata[log_learning_params].to_numpy()
 			log_norm_dict['mean'] = np.mean(np.log(log_data),axis=0)
 			log_norm_dict['std'] = np.std(np.log(log_data),axis=0)
-			norm_dict = norm_dict.append(log_norm_dict)
+			norm_dict = pd.concat([norm_dict, log_norm_dict], ignore_index=True)
 
 		# Set parameter to the index
 		norm_dict = norm_dict.set_index('parameter')

--- a/paltas/MainDeflector/simple_deflectors.py
+++ b/paltas/MainDeflector/simple_deflectors.py
@@ -63,7 +63,9 @@ class PEMD(MainDeflectorBase):
 		# Use lenstronomy to sort the parameters
 		for model in md_model_list:
 			# The list of parameters linked to that lenstronomy model
-			p_names = ProfileListBase._import_class(model,None,None).param_names
+			p_names = (
+				ProfileListBase._import_class(model,None,None,None).param_names
+			)
 			model_kwargs = {}
 			for param in p_names:
 				model_kwargs[param] = (self.main_deflector_parameters[param])
@@ -130,7 +132,9 @@ class PEMDShear(MainDeflectorBase):
 		# Use lenstronomy to sort the parameters
 		for model in md_model_list:
 			# The list of parameters linked to that lenstronomy model
-			p_names = ProfileListBase._import_class(model,None,None).param_names
+			p_names = (
+				ProfileListBase._import_class(model,None,None,None).param_names
+			)
 			model_kwargs = {}
 			for param in p_names:
 				model_kwargs[param] = (self.main_deflector_parameters[param])

--- a/paltas/Sampling/distributions.py
+++ b/paltas/Sampling/distributions.py
@@ -101,8 +101,8 @@ class TruncatedMultivariateNormal():
 		draws = (self.mean.T+np.dot(self.L,rand_draw)).T
 
 		# Check which draws are within our bounds
-		keep_ind = np.prod(draws > self.min_values,axis=-1,dtype=np.bool)
-		keep_ind *= np.prod(draws < self.max_values,axis=-1,dtype=np.bool)
+		keep_ind = np.prod(draws > self.min_values,axis=-1,dtype=bool)
+		keep_ind *= np.prod(draws < self.max_values,axis=-1,dtype=bool)
 		keep_draws[n_accepted:n_accepted+np.sum(keep_ind)] = draws[keep_ind]
 		n_accepted += np.sum(keep_ind)
 
@@ -113,8 +113,8 @@ class TruncatedMultivariateNormal():
 				(self.mean.shape[1],n_samp))
 			draws = (self.mean.T+np.dot(self.L,rand_draw)).T
 			# Check for the values in bounds
-			keep_ind = np.prod(draws > self.min_values,axis=-1,dtype=np.bool)
-			keep_ind *= np.prod(draws < self.max_values,axis=-1,dtype=np.bool)
+			keep_ind = np.prod(draws > self.min_values,axis=-1,dtype=bool)
+			keep_ind *= np.prod(draws < self.max_values,axis=-1,dtype=bool)
 			# Only use the ones we need
 			use_keep = np.minimum(n-n_accepted,np.sum(keep_ind))
 			keep_draws[n_accepted:n_accepted+use_keep] = (
@@ -129,16 +129,16 @@ class TruncatedMultivariateNormal():
 
 
 class EllipticitiesTranslation():
-	"""Class that takes in distributions for q_lens and phi_lens, returns 
+	"""Class that takes in distributions for q_lens and phi_lens, returns
 	samples of e1 and e2 correspondingly
-	
-	Args: 
-		q_dist (scipy.stats.rv_continuous.rvs or float): distribution for 
+
+	Args:
+		q_dist (scipy.stats.rv_continuous.rvs or float): distribution for
 			axis ratio (can be callable or constant)
-		phi_dist (scipy.stats.rv_continuous.rvs or float): distribution for 
+		phi_dist (scipy.stats.rv_continuous.rvs or float): distribution for
 			orientation angle in radians (can be callable or constant)
 
-	Notes: 
+	Notes:
 
 	"""
 	def __init__(self,q_dist,phi_dist):
@@ -146,10 +146,10 @@ class EllipticitiesTranslation():
 		self.phi_dist = phi_dist
 
 	def __call__(self):
-		"""Returns a sample of e1,e2 
+		"""Returns a sample of e1,e2
 
 		Returns:
-			(float,float): samples of x-direction ellipticity 
+			(float,float): samples of x-direction ellipticity
 				eccentricity, xy-direction ellipticity eccentricity
 		"""
 
@@ -161,7 +161,7 @@ class EllipticitiesTranslation():
 			phi = self.phi_dist()
 		else:
 			phi = self.phi_dist
-		
+
 		e1 = (1 - q)/(1+q) * np.cos(2*phi)
 		e2 = (1 - q)/(1+q) * np.sin(2*phi)
 
@@ -169,27 +169,27 @@ class EllipticitiesTranslation():
 
 
 class ExternalShearTranslation():
-	"""Class that maps samples of gamma_ext, phi_ext distributions to 
+	"""Class that maps samples of gamma_ext, phi_ext distributions to
 		gamma1, gamma2
-	
-	Args: 
-		gamma_dist (scipy.stats.rv_continuous.rvs or float): distribution for 
-			external shear modulus (callable or constant) 
-		phi_dist (scipy.stats.rv_continuous.rvs or float): distribution for 
+
+	Args:
+		gamma_dist (scipy.stats.rv_continuous.rvs or float): distribution for
+			external shear modulus (callable or constant)
+		phi_dist (scipy.stats.rv_continuous.rvs or float): distribution for
 			orientation angle in radians (callable or constant)
-	
+
 	Notes:
 	"""
 
 	def __init__(self, gamma_dist,phi_dist):
 		self.gamma_dist = gamma_dist
 		self.phi_dist = phi_dist
-	
+
 	def __call__(self):
 		"""Returns gamma1, gamma2 samples
 
 		Returns:
-			(float,float): samples of external shear coordinate values 
+			(float,float): samples of external shear coordinate values
 		"""
 		if callable(self.gamma_dist):
 			gamma = self.gamma_dist()
@@ -199,20 +199,20 @@ class ExternalShearTranslation():
 			phi = self.phi_dist()
 		else:
 			phi = self.phi_dist
-		
+
 		gamma1 = gamma * np.cos(2*phi)
 		gamma2 = gamma * np.sin(2*phi)
-		
+
 		return gamma1,gamma2
 
 
 class KappaTransformDistribution():
-	"""Class that samples Kext given 1 / (1-Kext) ~ n. n is sampled from a 
+	"""Class that samples Kext given 1 / (1-Kext) ~ n. n is sampled from a
 	distribution given by n_dist, then Kext is computed given the
 	transformation
-	
-	Args: 
-		n_dist (scipy.stats.rv_continuous.rvs or float): distribution for 
+
+	Args:
+		n_dist (scipy.stats.rv_continuous.rvs or float): distribution for
 			1 / (1-Kext) (can be callable or constant)
 	"""
 
@@ -222,14 +222,14 @@ class KappaTransformDistribution():
 	def __call__(self):
 		"""Samples 1/(1-Kext), then maps that sample to Kext value
 
-		Returns: 
+		Returns:
 			(float): Kext sample
 		"""
 		if callable(self.n_dist):
 			n = self.n_dist()
 		else:
 			n = self.n_dist
-		
+
 		return 1 - (1/n)
 
 
@@ -287,20 +287,20 @@ class DuplicateScatter(Duplicate):
 
 
 class DuplicateXY():
-	"""Class that returns two copies of x, y coordinates drawn from 
+	"""Class that returns two copies of x, y coordinates drawn from
 		distributions
 
-	Args: 
-		x_dist (scipy.stats.rv_continuous.rvs or float): distribution for x 
+	Args:
+		x_dist (scipy.stats.rv_continuous.rvs or float): distribution for x
 			(can be callable or constant)
-		y_dist (scipy.stats.rv_continuous.rvs or float): distribution for y 
+		y_dist (scipy.stats.rv_continuous.rvs or float): distribution for y
 			(can be callable or constant)
 	"""
 
 	def __init__(self,x_dist,y_dist):
 		self.x_dist = x_dist
 		self.y_dist = y_dist
-	
+
 	def __call__(self):
 		"""Returns two copies of x,y sample
 
@@ -317,15 +317,15 @@ class DuplicateXY():
 			y = self.y_dist()
 		else:
 			y = self.y_dist
-		
+
 		return x,y,x,y
 
 
 class RedshiftsTruncNorm():
-	"""Class that samples z_lens and z_source from truncated normal 
+	"""Class that samples z_lens and z_source from truncated normal
 		distributions, forcing z_source > z_lens to be true
 
-	Args: 
+	Args:
 		z_lens_min (float): minimum allowed lens redshift
 		z_lens_mean (float): lens redshift mean
 		z_lens_std (float): lens redshift standard deviation
@@ -337,7 +337,7 @@ class RedshiftsTruncNorm():
 	def __init__(self, z_lens_min,z_lens_mean,z_lens_std,z_source_min,
 		z_source_mean,z_source_std):
 		# transform z_lens_min, z_source_min to be in units of std. deviations
-		self.z_lens_min = (z_lens_min - z_lens_mean) / z_lens_std 
+		self.z_lens_min = (z_lens_min - z_lens_mean) / z_lens_std
 		self.z_source_min = (z_source_min - z_source_mean) / z_source_std
 		# define truncnorm dist for lens redshift
 		self.z_lens_dist = truncnorm(self.z_lens_min,np.inf,loc=z_lens_mean,
@@ -345,12 +345,12 @@ class RedshiftsTruncNorm():
 		# save z_source info
 		self.z_source_mean = z_source_mean
 		self.z_source_std = z_source_std
-	
+
 	def __call__(self):
 		"""Returns samples of redshifts, ensuring z_source > z_lens
 
-		Returns: 
-			(float,float): z_lens,z_source 
+		Returns:
+			(float,float): z_lens,z_source
 		"""
 		z_lens = self.z_lens_dist()
 		clip = (z_lens - self.z_source_mean) / self.z_source_std
@@ -400,11 +400,11 @@ class MultipleValues():
 	def __init__(self, dist, num):
 		self.dist = dist
 		self.num = num
-	
+
 	def __call__(self):
 		"""Returns specified # of samples from dist
-		
-		Returns: 
+
+		Returns:
 			list(float): |num| samples from dist
 		"""
 		return self.dist(size=self.num)

--- a/paltas/Sources/cosmos.py
+++ b/paltas/Sources/cosmos.py
@@ -101,7 +101,7 @@ class COSMOSCatalog(GalaxyCatalog):
 			# Custom fields
 			catalogs += [
 				np.zeros(len(catalogs[0]),
-					dtype=[('size_x', np.int),('size_y', np.int),('z', float),
+					dtype=[('size_x', int),('size_y', int),('z', float),
 					('pixel_width', float)])]
 
 			self.catalog = numpy.lib.recfunctions.merge_arrays(
@@ -117,7 +117,7 @@ class COSMOSCatalog(GalaxyCatalog):
 				# Grab the shape of each image.
 				meta['size_x'], meta['size_y'] = img.shape
 				# Save the image as its own image.
-				img = img.astype(np.float)
+				img = img.astype(np.float64)
 				np.save(str(self.npy_files_path/('img_%d.npy'%(catalog_i))),img)
 				catalog_i += 1
 
@@ -271,7 +271,7 @@ class COSMOSSersicCatalog(COSMOSCatalog):
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
 
-		_fit_results = self.catalog['sersicfit'].astype(np.float)
+		_fit_results = self.catalog['sersicfit'].astype(np.float64)
 		self.sercic_info = {
 			p: _fit_results[:, i]
 			for i, p in enumerate(

--- a/test/analysis_tests.py
+++ b/test/analysis_tests.py
@@ -135,7 +135,7 @@ class DatasetGenerationTests(unittest.TestCase):
 		norm_dict = Analysis.dataset_generation.normalize_outputs(metadata,
 			learning_params,input_norm_path)
 
-		mean = np.array([[1,2]]*2,dtype=np.float)
+		mean = np.array([[1,2]]*2,dtype=np.float64)
 		cov_mat = np.array([[[1,0.9],[0.9,1]]]*2)
 
 		Analysis.dataset_generation.unnormalize_outputs(input_norm_path,

--- a/test/utils_tests.py
+++ b/test/utils_tests.py
@@ -135,7 +135,7 @@ class CosmologyTests(unittest.TestCase):
 		dd *= 1/h * u.Mpc.to(u.kpc)/u.radian.to(u.arcsecond)
 		np.testing.assert_almost_equal(cosmology_utils.kpc_per_arcsecond(
 			z_test,cosmo),dd,decimal=4)
-	
+
 	def test_ddt(self):
 		# Check that calculation agrees with lenstronomy version
 		cosmo = cosmology_utils.get_cosmology('planck18')
@@ -351,7 +351,7 @@ class HubbleUtilsTests(unittest.TestCase):
 	def test_degrade_image(self):
 		# Test that the degraded image gives the output we'd expect.
 		fake_image = np.array([[0,1,2,3],[4,5,6,7],[8,9,10,11],[12,13,14,15]],
-			dtype=np.float)
+			dtype=np.float64)
 
 		# Start by degrading by a factor of 2
 		degrade_factor = 2


### PR DESCRIPTION
Deprecation with respect to newer version of packages like numpy is causing tests to fail. Fixing those deprecation errors.