### PR TITLE
fix calls to lenstronomy for new version

### DIFF
--- a/paltas/Configs/config_handler.py
+++ b/paltas/Configs/config_handler.py
@@ -478,7 +478,7 @@ class ConfigHandler():
 		if 'lens_equation_solver_parameters' in sample.keys():
 			lens_equation_params = sample['lens_equation_solver_parameters']
 		point_source_model = PointSource(
-			kwargs_model['point_source_model_list'],lensModel=lens_model,
+			kwargs_model['point_source_model_list'],lens_model=lens_model,
 			save_cache=True,kwargs_lens_eqn_solver=lens_equation_params)
 
 		# Put it together into an image model

--- a/paltas/MainDeflector/simple_deflectors.py
+++ b/paltas/MainDeflector/simple_deflectors.py
@@ -7,7 +7,7 @@ This module contains the classes to render main deflectors consisting of simple
 combinations of lenstronomy profiles.
 """
 from .main_deflector_base import MainDeflectorBase
-from lenstronomy.LensModel.profile_list_base import ProfileListBase
+from lenstronomy.LensModel.profile_list_base import lens_class
 
 
 class PEMD(MainDeflectorBase):
@@ -64,7 +64,7 @@ class PEMD(MainDeflectorBase):
 		for model in md_model_list:
 			# The list of parameters linked to that lenstronomy model
 			p_names = (
-				ProfileListBase._import_class(model,None,None,None).param_names
+				lens_class(model).param_names
 			)
 			model_kwargs = {}
 			for param in p_names:
@@ -133,7 +133,7 @@ class PEMDShear(MainDeflectorBase):
 		for model in md_model_list:
 			# The list of parameters linked to that lenstronomy model
 			p_names = (
-				ProfileListBase._import_class(model,None,None,None).param_names
+				lens_class(model).param_names
 			)
 			model_kwargs = {}
 			for param in p_names:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 astropy>=4.0.0
 colossus
 drizzle>=1.13.3
-lenstronomy>=1.11.5
+lenstronomy>=1.11.6
 numpy>=1.13,<=1.24
 scipy>=1.7
 tqdm>=4.42.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 astropy>=4.0.0
 colossus
 drizzle>=1.13.3
-lenstronomy>=1.6.0
+lenstronomy>=1.11.5
 numpy>=1.13,<=1.24
 scipy>=1.7
 tqdm>=4.42.1

--- a/test/config_tests.py
+++ b/test/config_tests.py
@@ -154,7 +154,7 @@ class ConfigUtilsTests(unittest.TestCase):
 			lens_redshift_list=kwargs_model['lens_redshift_list'],
 			cosmo=cosmo.toAstropy(),multi_plane=kwargs_model['multi_plane'])
 		point_source_model = PointSource(
-			kwargs_model['point_source_model_list'],lensModel=lens_model,
+			kwargs_model['point_source_model_list'],lens_model=lens_model,
 			save_cache=True,kwargs_lens_eqn_solver=lens_equation_params)
 
 		# Initialize empty metadata and populate it.


### PR DESCRIPTION
- PointSource() now takes in 'lens_model' instead of 'lensModel' as a kwarg (change to config_handler.py)
- remove use of a private function in MainDeflector.simple_deflectors.py 
