### PR TITLE
Fix for truncated redshift distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ lib64
 
 # COSMOS images
 datasets/cosmos
+/paltas/example/*
+/paltas/example_validation/*
+/paltas/example_network_weights/*
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,3 @@ lib64
 
 # COSMOS images
 datasets/cosmos
-/paltas/example/*
-/paltas/example_validation/*
-/paltas/example_network_weights/*
-*.DS_Store

--- a/paltas/Sampling/distributions.py
+++ b/paltas/Sampling/distributions.py
@@ -338,7 +338,7 @@ class RedshiftsTruncNorm():
 		z_source_mean,z_source_std):
 		# transform z_lens_min, z_source_min to be in units of std. deviations
 		self.z_lens_min = (z_lens_min - z_lens_mean) / z_lens_std 
-		self.z_source_min = (z_source_min - z_source_mean) / z_source_std
+		self.z_source_min_default = (z_source_min - z_source_mean) / z_source_std
 		# define truncnorm dist for lens redshift
 		self.z_lens_dist = truncnorm(self.z_lens_min,np.inf,loc=z_lens_mean,
 			scale=z_lens_std).rvs
@@ -355,8 +355,9 @@ class RedshiftsTruncNorm():
 		z_lens = self.z_lens_dist()
 		clip = (z_lens - self.z_source_mean) / self.z_source_std
 		# number of std. devs away to stop (negative)
-		if(clip > self.z_source_min):
+		if(clip > self.z_source_min_default):
 			self.z_source_min = clip
+		else: self.z_source_min = self.z_source_min_default
 		# define truncnorm dist for source redshift
 		z_source = truncnorm(self.z_source_min,np.inf,self.z_source_mean,
 			self.z_source_std).rvs()


### PR DESCRIPTION
Fix for minor bug for the RedshiftsTruncNorm class

Description of Bug:
The lower source redshift truncation value (self.z_source_min) is updated dependent on the lens redshift, but is not reset to the default/inputted value after each draw. Therefore the truncation value gradually increases as more draws are made.
Fix:
The lower truncation value is now set to the inputted value (self.z_source_min_default) in the cases that it is greater than the lens redshift.